### PR TITLE
Separate log tables

### DIFF
--- a/pg_ninja/lib/pg_lib.py
+++ b/pg_ninja/lib/pg_lib.py
@@ -100,13 +100,14 @@ class pg_engine:
 		self.type_ddl={}
 		self.pg_charset=self.pg_conn.pg_charset
 		self.batch_retention = global_config.batch_retention
-		self.cat_version='0.11'
+		self.cat_version='0.12'
 		self.cat_sql=[
 			{'version':'base','script': 'create_schema.sql'}, 
 			{'version':'0.8','script': 'upgrade/cat_0.8.sql'}, 
 			{'version':'0.9','script': 'upgrade/cat_0.9.sql'}, 
 			{'version':'0.10','script': 'upgrade/cat_0.10.sql'}, 
 			{'version':'0.11','script': 'upgrade/cat_0.11.sql'}, 
+			{'version':'0.12','script': 'upgrade/cat_0.12.sql'}, 
 			
 		]
 		cat_version=self.get_schema_version()

--- a/sql/upgrade/cat_0.12.sql
+++ b/sql/upgrade/cat_0.12.sql
@@ -1,0 +1,110 @@
+ALTER TABLE sch_ninja.t_sources ADD  v_log_table character varying[];
+UPDATE sch_ninja.t_sources 
+	SET v_log_table=ARRAY[
+		format('t_log_replica_1_src_%s',i_id_source),
+		format('t_log_replica_2_src_%s',i_id_source)
+	]
+;
+
+
+CREATE OR REPLACE FUNCTION sch_ninja.fn_refresh_parts() 
+RETURNS VOID as 
+$BODY$
+DECLARE
+    t_sql text;
+    r_tables record;
+BEGIN
+    FOR r_tables IN SELECT unnest(v_log_table) as v_log_table FROM sch_ninja.t_sources
+    LOOP
+        RAISE DEBUG 'CREATING TABLE %', r_tables.v_log_table;
+        t_sql:=format('
+                        CREATE TABLE IF NOT EXISTS sch_ninja.%I
+                        (
+                        CONSTRAINT pk_%s PRIMARY KEY (i_id_event),
+                          CONSTRAINT fk_%s FOREIGN KEY (i_id_batch) 
+                        	REFERENCES  sch_ninja.t_replica_batch (i_id_batch)
+                    	ON UPDATE RESTRICT ON DELETE CASCADE
+                        )
+                        INHERITS (sch_ninja.t_log_replica)
+                        ;',
+                        r_tables.v_log_table,
+                        r_tables.v_log_table,
+                        r_tables.v_log_table
+                );
+        EXECUTE t_sql;
+    END LOOP;
+END
+$BODY$
+LANGUAGE plpgsql 
+;
+
+DO LANGUAGE plpgsql 
+$BODY$
+DECLARE
+    t_sql text;
+    r_tables record;
+BEGIN
+    FOR r_tables IN SELECT unnest(v_log_table) as v_log_table FROM sch_ninja.t_sources
+    LOOP
+        RAISE NOTICE 'CREATING TABLE %', r_tables.v_log_table;
+        t_sql:=format('
+                        CREATE TABLE IF NOT EXISTS sch_ninja.%I
+                        (
+                        CONSTRAINT pk_%s PRIMARY KEY (i_id_event),
+                          CONSTRAINT fk_%s FOREIGN KEY (i_id_batch) 
+                        	REFERENCES  sch_ninja.t_replica_batch (i_id_batch)
+                    	ON UPDATE RESTRICT ON DELETE CASCADE
+                        )
+                        INHERITS (sch_ninja.t_log_replica)
+                        ;',
+                        r_tables.v_log_table,
+                        r_tables.v_log_table,
+                        r_tables.v_log_table
+                );
+        EXECUTE t_sql;
+    END LOOP;
+    FOR r_tables IN SELECT i_id_source,v_log_table[1] AS v_log_table FROM sch_ninja.t_sources
+    LOOP
+        t_sql:=format('
+            INSERT INTO sch_ninja.%I 
+            SELECT 
+                log.* 
+            FROM
+                sch_ninja.t_log_replica_1 log
+                INNER JOIN sch_ninja.t_replica_batch bat
+                ON log.i_id_batch=bat.i_id_batch
+            WHERE
+                bat.i_id_source=%L
+            ON CONFLICT DO NOTHING   
+            ;'
+            ,
+            r_tables.v_log_table,
+            r_tables.i_id_source
+            
+        );
+        EXECUTE t_sql;
+        t_sql:=format('
+            INSERT INTO sch_ninja.%I 
+            SELECT 
+                log.* 
+            FROM
+                sch_ninja.t_log_replica_2 log
+                INNER JOIN sch_ninja.t_replica_batch bat
+                ON log.i_id_batch=bat.i_id_batch
+            WHERE
+                bat.i_id_source=%L
+            ON CONFLICT DO NOTHING   
+            ;'
+            ,
+            r_tables.v_log_table,
+            r_tables.i_id_source
+            
+        );
+        EXECUTE t_sql;
+    END LOOP;
+    DROP TABLE sch_ninja.t_log_replica_1;
+    DROP TABLE sch_ninja.t_log_replica_2;
+END
+$BODY$
+;
+ALTER TABLE sch_ninja.t_replica_batch DROP COLUMN v_log_table;


### PR DESCRIPTION
split the log replica tables in per source tables in order to limit the bloat 